### PR TITLE
feat(docker): build using debootstrap instead of downloading .img

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,13 @@ jobs:
         include:
           - tags: ${{ vars.DOCKERHUB_USERNAME }}/raspios:arm64,${{ vars.DOCKERHUB_USERNAME }}/raspios:arm64-20251204
             platforms: linux/arm64
-            build-args: RASPIOS_URL=https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2025-12-04/2025-12-04-raspios-trixie-arm64-lite.img.xz
+            build-args: |
+              SUITE=trixie
+              MIRROR=http://deb.debian.org/debian
+              ARCH=arm64
           - tags: ${{ vars.DOCKERHUB_USERNAME }}/raspios:armhf,${{ vars.DOCKERHUB_USERNAME }}/raspios:armhf-20251204
             platforms: linux/arm/v6,linux/arm/v7,linux/arm64
-            build-args: RASPIOS_URL=https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2025-12-04/2025-12-04-raspios-trixie-armhf-lite.img.xz
+            build-args: |
+              SUITE=trixie
+              MIRROR=http://raspbian.raspberrypi.com/raspbian/
+              ARCH=armhf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,17 @@
 FROM --platform=$BUILDPLATFORM debian:stable-20260223-slim AS extractor
 
-ARG RASPIOS_URL
-
-ADD ${RASPIOS_URL} raspios.img.xz
+ARG SUITE
+ARG MIRROR
+ARG ARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV LIBGUESTFS_BACKEND=direct
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libguestfs-tools \
-    xz-utils \
-    "linux-image-$(dpkg --print-architecture)"
+    ca-certificates \
+    debootstrap \
+    wget
 
-RUN unxz raspios.img.xz && \
-    guestfish --ro -a raspios.img -m /dev/sda2 \
-        -- set-autosync false : copy-out / /mnt/
+RUN debootstrap --arch=${ARCH} --no-check-gpg ${SUITE} /mnt ${MIRROR}
 
 FROM scratch
 


### PR DESCRIPTION
This PR replaces the method for generating the Docker image from downloading and modifying a full `raspios.img` to building the root filesystem directly using `debootstrap`.

### Changes made
- **`Dockerfile`**: Instead of pulling the `.img` and using `guestfish` to extract partitions, we download `debootstrap` and create an image from the Debian/Raspberry Pi package mirrors directly. This solves issues with bloated image size and makes the build more robust.
- **`.github/workflows/docker.yml`**: Provided `SUITE`, `MIRROR`, and `ARCH` arguments to trigger multi-architecture base image builds properly using the new method.

Fixes #14