### PR TITLE
Add checksum validation and pin debian image to SHA

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,19 +28,24 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Fetch checksum
+        id: fetch_checksum
+        run: echo "sha256=$(curl -sS "${{ matrix.raspios_url }}.sha256" | awk '{print $1}')" >> $GITHUB_OUTPUT
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           push:  ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: ${{ matrix.tags }}
           platforms: ${{ matrix.platforms }}
-          build-args: ${{ matrix.build-args }}
+          build-args: |
+            RASPIOS_URL=${{ matrix.raspios_url }}
+            RASPIOS_SHA256=${{ steps.fetch_checksum.outputs.sha256 }}
     strategy:
       matrix:
         include:
           - tags: ${{ vars.DOCKERHUB_USERNAME }}/raspios:arm64,${{ vars.DOCKERHUB_USERNAME }}/raspios:arm64-20251204
             platforms: linux/arm64
-            build-args: RASPIOS_URL=https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2025-12-04/2025-12-04-raspios-trixie-arm64-lite.img.xz
+            raspios_url: https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2025-12-04/2025-12-04-raspios-trixie-arm64-lite.img.xz
           - tags: ${{ vars.DOCKERHUB_USERNAME }}/raspios:armhf,${{ vars.DOCKERHUB_USERNAME }}/raspios:armhf-20251204
             platforms: linux/arm/v6,linux/arm/v7,linux/arm64
-            build-args: RASPIOS_URL=https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2025-12-04/2025-12-04-raspios-trixie-armhf-lite.img.xz
+            raspios_url: https://downloads.raspberrypi.com/raspios_lite_armhf/images/raspios_lite_armhf-2025-12-04/2025-12-04-raspios-trixie-armhf-lite.img.xz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM --platform=$BUILDPLATFORM debian:stable-20260223-slim AS extractor
+FROM --platform=$BUILDPLATFORM debian:stable-slim@sha256:85dfcffff3c1e193877f143d05eaba8ae7f3f95cb0a32e0bc04a448077e1ac69 AS extractor
 
 ARG RASPIOS_URL
+ARG RASPIOS_SHA256
 
-ADD ${RASPIOS_URL} raspios.img.xz
+ADD --checksum=sha256:${RASPIOS_SHA256} ${RASPIOS_URL} raspios.img.xz
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LIBGUESTFS_BACKEND=direct
@@ -14,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN unxz raspios.img.xz && \
     guestfish --ro -a raspios.img -m /dev/sda2 \
-        -- set-autosync false : copy-out / /mnt/
+    -- set-autosync false : copy-out / /mnt/
 
 FROM scratch
 


### PR DESCRIPTION
This PR addresses user feedback to pin the `debian:stable-slim` base image to a specific SHA256 tag, ensuring the build base is truly immutable. It also adds checksum validation for the downloaded Raspberry Pi OS images before extracting them, to prevent corruption or incomplete downloads.

Resolves #16.