### PR TITLE
Feat: Make raspios:latest point to arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,10 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/raspios:{1},{0}/raspios:{1}-{2}', vars.DOCKERHUB_USERNAME, matrix.arch, steps.prep_vars.outputs.date) || format('{0}/raspios:{1}', vars.DOCKERHUB_USERNAME, matrix.arch) }}
+          tags: |
+            ${{ format('{0}/raspios:{1}', vars.DOCKERHUB_USERNAME, matrix.arch) }}
+            ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/raspios:{1}-{2}', vars.DOCKERHUB_USERNAME, matrix.arch, steps.prep_vars.outputs.date) || '' }}
+            ${{ matrix.arch == 'arm64' && format('{0}/raspios:latest', vars.DOCKERHUB_USERNAME) || '' }}
           platforms: ${{ matrix.platforms }}
           build-args: |
             RASPIOS_URL=${{ steps.prep_vars.outputs.url }}

--- a/README.md
+++ b/README.md
@@ -16,13 +16,12 @@ root filesystems (32-bit and 64-bit variants) and publishes them to Docker Hub:
 [https://hub.docker.com/r/vascoguita/raspios](https://hub.docker.com/r/vascoguita/raspios).
 
 ## Docker Images :whale:
-
-| Tag              | Architectures               | Description                                                      |
-|------------------|-----------------------------|------------------------------------------------------------------|
-| `arm64`          | `arm64`                     | Image with the latest 64-bit Raspberry Pi OS Lite release        |
-| `armhf`          | `arm/v6`, `arm/v7`, `arm64` | Image with the latest 32-bit Raspberry Pi OS Lite release        |
-| `arm64-YYYYMMDD` | `arm64`                     | Image with the 64-bit Raspberry Pi OS Lite release of YYYY-MM-DD |
-| `armhf-YYYYMMDD` | `arm/v6`, `arm/v7`, `arm64` | Image with the 32-bit Raspberry Pi OS Lite release of YYYY-MM-DD |
+| Tag               | Architectures               | Description                                                      |
+|-------------------|-----------------------------|------------------------------------------------------------------|
+| `latest`, `arm64` | `arm64`                     | Image with the latest 64-bit Raspberry Pi OS Lite release        |
+| `armhf`           | `arm/v6`, `arm/v7`, `arm64` | Image with the latest 32-bit Raspberry Pi OS Lite release        |
+| `arm64-YYYYMMDD`  | `arm64`                     | Image with the 64-bit Raspberry Pi OS Lite release of YYYY-MM-DD |
+| `armhf-YYYYMMDD`  | `arm/v6`, `arm/v7`, `arm64` | Image with the 32-bit Raspberry Pi OS Lite release of YYYY-MM-DD |
 
 > ### Note
 >


### PR DESCRIPTION
Resolves #24

- Refactored workflow matrix and push logic
- Tagged arm64 image as latest
- Updated README documentation