### PR TITLE
Skip redundant scheduled builds

### DIFF
--- a/.github/scripts/matrix.sh
+++ b/.github/scripts/matrix.sh
@@ -29,6 +29,12 @@ for arch in "${!PLATFORMS[@]}"; do
     curl -fsSLI "https://hub.docker.com/v2/repositories/${DOCKERHUB_REPO}/tags/${arch}-${suite}-${date}/" \
       >/dev/null 2>&1 || tags="${arch}-${suite}-${date}"
 
+    [[ -z "$tags" && "${GITHUB_EVENT_NAME:-}" == "schedule" ]] && {
+      SEEN_ARCH[$arch]=1
+      SEEN_SUITE["${arch}-${suite}"]=1
+      continue
+    }
+
     [[ -z "${SEEN_ARCH[$arch]:-}" ]] && {
       [[ "$arch" == "arm64" ]] && tags="${tags},arm64,latest" || tags="${tags},armhf"
       SEEN_ARCH[$arch]=1


### PR DESCRIPTION
Closes #39

## Description 📄

On scheduled runs, skip matrix entries when the immutable tag already exists on Docker Hub. This prevents redundant builds and pushes of mutable tags when there are no new Raspberry Pi OS releases.

Behavior by trigger:
- **schedule**: Only builds when a new release is detected (empty matrix otherwise).
- **push/PR**: Unchanged; rebuilds mutable tags when Dockerfile or pipeline files change.
- **workflow_dispatch**: Unchanged; rebuilds everything on manual trigger.